### PR TITLE
Naming convention for service functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,8 +471,8 @@ Many of my styles have been from the many pair programming sessions [Ward Bell](
 
 ## Services
 
-  - **Singletons**: Services are instantiated with the `new` keyword, use `this` for public methods and variables. Can also use a factory, which I recommend for consistency. 
-  
+  - **Singletons**: Services are instantiated with the `new` keyword, use `this` for public methods and variables. Can also use a factory, which I recommend for consistency.
+
     - Note: [All AngularJS services are singletons](https://docs.angularjs.org/guide/services). This means that there is only one instance of a given service per injector.
 
     ```javascript
@@ -480,9 +480,9 @@ Many of my styles have been from the many pair programming sessions [Ward Bell](
 
     angular
         .module('app')
-        .service('logger', logger);
+        .service('logger', Logger);
 
-    function logger () {
+    function Logger () {
       this.logError = function (msg) {
         /* */
       };


### PR DESCRIPTION
Shouldn't services follow the upper camel case naming convention since they are instantiated with 'new' just like controllers (following the constructor pattern)?  Factories should remain following the lower camel case naming convention since they are just returned as functions following the revealing module pattern.
