### PR TITLE
changed `getter` to `setter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Many of my styles have been from the many pair programming sessions [Ward Bell](
     ]);
     ```
 
-	Instead use the simple getter syntax.
+	Instead use the simple setter syntax.
 
     ```javascript
     /* recommended */


### PR DESCRIPTION
In the Modules section there is an example of the setter syntax to create a module, but it said it was using the getter syntax.
