### PR TITLE
Fixed "why" sentence for Factory Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1601,7 +1601,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
     
   - **Factory Names**: Use consistent names for all factories named after their feature. Use camel-casing for services and factories.
 
-      *Why?*: Provides a consistent way to quickly identify and reference controllers.
+      *Why?*: Provides a consistent way to quickly identify and reference factories.
 
     ```javascript
     /**


### PR DESCRIPTION
Changed the word "controllers" to "factories" in the "why" sentence for
Factory Names.
