### PR TITLE
README - Fixed Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
 
 ### Function Declarations to Hide Implementation Details
 
-  - Use function declarations to hide implementation details. Keep your acessible members of the factory up top. Point those to function declarations that appears later in the file. For more details see [this post](http://www.johnpapa.net/angular-function-declarations-function-expressions-and-readable-code).
+  - Use function declarations to hide implementation details. Keep your accessible members of the factory up top. Point those to function declarations that appears later in the file. For more details see [this post](http://www.johnpapa.net/angular-function-declarations-function-expressions-and-readable-code).
 
     *Why?*: Placing accessible members at the top makes it easy to read and helps you instantly identify which functions of the factory you can access externally.
 


### PR DESCRIPTION
I noticed a typo in the 'Function Declarations to Hide Implementation Details' Portion. I changed acessible to accessible. Nothing else was altered. Thanks so much for this amazing guide!
