### PR TITLE
Typo: Inconsistent Style Code Y035/Y036

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
   ```
 
 ### Defer Controller Logic
-###### [Style [Y035](#style-y036)]
+###### [Style [Y035](#style-y035)]
 
   - Defer logic in a controller by delegating to services and factories.
 


### PR DESCRIPTION
Style “Defer Controller Logic” has an inconsistent style code: Y035 in the link text and Y036 in the link URL. I don’t know which of the two is more correct. This commit changes the URL to Y035 in order to keep existing links working.
