### PR TITLE
Use Karma module directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2406,7 +2406,7 @@ Unit testing helps maintain clean code, as such I included some of my recommenda
 
     *Why?*: Some IDE's are beginning to integrate with Karma, such as [WebStorm](http://www.jetbrains.com/webstorm/) and [Visual Studio](http://visualstudiogallery.msdn.microsoft.com/02f47876-0e7a-4f6c-93f8-1af5d5189225).
 
-    *Why?*: Karma works well with task automation leaders such as [Grunt](http://www.gruntjs.com) (with [grunt-karma](https://github.com/karma-runner/grunt-karma)) and [Gulp](http://www.gulpjs.com) (with [gulp-karma](https://github.com/lazd/gulp-karma)).
+    *Why?*: Karma works well with task automation leaders such as [Grunt](http://www.gruntjs.com) (with [grunt-karma](https://github.com/karma-runner/grunt-karma)) and [Gulp](http://www.gulpjs.com) (with [Karma's public API](https://github.com/karma-runner/gulp-karma)).
 
 ### Stubbing and Spying
 ###### [Style [Y193](#style-y193)]

--- a/i18n/fr-FR.md
+++ b/i18n/fr-FR.md
@@ -2382,7 +2382,7 @@ Les tests unitaires aident à maintenir un code propre, ainsi, j'ai inclu quelqu
 
     *Pourquoi ?* : Quelques EDI commencent à s'intégrer avec Karma, c'est le cas de [WebStorm](http://www.jetbrains.com/webstorm/) et [Visual Studio](http://visualstudiogallery.msdn.microsoft.com/02f47876-0e7a-4f6c-93f8-1af5d5189225).
 
-    *Pourquoi ?* : Karma fonctionne bien avec les leaders de l'automatisation de tâches tel que [Grunt](http://www.gruntjs.com) (avec [grunt-karma](https://github.com/karma-runner/grunt-karma)) ou [Gulp](http://www.gulpjs.com) (avec [gulp-karma](https://github.com/lazd/gulp-karma)).
+    *Pourquoi ?* : Karma fonctionne bien avec les leaders de l'automatisation de tâches tel que [Grunt](http://www.gruntjs.com) (avec [grunt-karma](https://github.com/karma-runner/grunt-karma)) ou [Gulp](http://www.gulpjs.com) (avec [l'API public de Karma](https://github.com/karma-runner/gulp-karma)).
 
 ### Les Stubs et les Spy
 ###### [Style [Y193](#style-y193)]


### PR DESCRIPTION
`gulp-karma` is [blacklisted](https://github.com/gulpjs/plugins/blob/master/src/blackList.json#L264)
We don't need any gulp plugins to run Karma with Gulp

More details: https://github.com/karma-runner/gulp-karma#do-we-need-a-plugin

