### PR TITLE
Fix moviesPrepService typo in Resolve section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1585,13 +1585,13 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
                 controller: 'AvengersController',
                 controllerAs: 'vm',
                 resolve: {
-                    moviesPrepService: moviePrepService
+                    moviesPrepService: moviesPrepService
                 }
             });
     }
 
-    moviePrepService.$inject = ['movieService'];
-    function moviePrepService(movieService) {
+    moviesPrepService.$inject = ['movieService'];
+    function moviesPrepService(movieService) {
         return movieService.getMovies();
     }
     ```

--- a/README.md
+++ b/README.md
@@ -1444,7 +1444,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
           });
   }
 
-  function moviePrepService(movieService) {
+  function moviesPrepService(movieService) {
       return movieService.getMovies();
   }
 


### PR DESCRIPTION
Fix moviesPrepService typo in Route Resolve section. It was previously just moviePrepService but this did not match how it was called in the resolve block.