### PR TITLE
Sublime snippets - Initializing $inject too

### DIFF
--- a/assets/sublime-angular-snippets/angular.controller.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.controller.sublime-snippet
@@ -6,7 +6,7 @@
         .module('${1:module}')
         .controller('${2:Controller}', ${2:Controller});
 
-    ${2:controller}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+    ${2:Controller}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
 
     /* @ngInject */
     function ${2:Controller}(${3:dependencies}) {

--- a/assets/sublime-angular-snippets/angular.controller.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.controller.sublime-snippet
@@ -6,6 +6,8 @@
         .module('${1:module}')
         .controller('${2:Controller}', ${2:Controller});
 
+    ${2:controller}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+
     /* @ngInject */
     function ${2:Controller}(${3:dependencies}) {
         var vm = this;

--- a/assets/sublime-angular-snippets/angular.directive.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.directive.sublime-snippet
@@ -6,6 +6,8 @@
         .module('${1:module}')
         .directive('${2:directive}', ${2:directive});
 
+    ${2:directive}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+
     /* @ngInject */
     function ${2:directive} (${3:dependencies}) {
         // Usage:

--- a/assets/sublime-angular-snippets/angular.factory.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.factory.sublime-snippet
@@ -6,6 +6,8 @@
         .module('${1:module}')
         .factory('${2:factory}', ${2:factory});
 
+    ${2:factory}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+
     /* @ngInject */
     function ${2:Factory}(${3:dependencies}) {
         var service = {

--- a/assets/sublime-angular-snippets/angular.service.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.service.sublime-snippet
@@ -6,6 +6,8 @@
         .module('${1:module}')
         .service('${2:Service}', ${2:Service});
 
+    ${2:Service}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+
     /* @ngInject */
     function ${2:Service}(${3:dependencies}) {
         this.${4:func} = ${4:func};


### PR DESCRIPTION
Initializing $inject property with regular expressions in the following snippets :
- ngController
- ngDirective
- ngFactory
- ngService

![ngsublimesnippetsdemo](https://cloud.githubusercontent.com/assets/9742804/7247744/0a20fc5c-e80d-11e4-8868-f88c981600f6.gif)
