### PR TITLE
Updated Back to top link position Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2902,6 +2902,8 @@ Use file templates or snippets to help follow consistent styles and patterns. He
     ngservice    // creates an Angular service
     ngfilter     // creates an Angular filter
     ```
+
+
 **[Back to top](#table-of-contents)**
 
 ## Yeoman Generator


### PR DESCRIPTION
In "File Templates and Snippets" section. Link was aligned as though it was part of the list above it.