### PR TITLE
Sublime Snippets for new files #445

### DIFF
--- a/assets/sublime-angular-snippets/angular.controller.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.controller.sublime-snippet
@@ -23,5 +23,5 @@
 })();
 ]]></content>
     <tabTrigger>ngcontroller</tabTrigger>
-    <scope>source.js</scope>
+    <scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.directive.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.directive.sublime-snippet
@@ -36,5 +36,5 @@
 })();
 ]]></content>
     <tabTrigger>ngdirective</tabTrigger>
-    <scope>source.js</scope>
+    <scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.factory.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.factory.sublime-snippet
@@ -23,5 +23,5 @@
 })();
 ]]></content>
     <tabTrigger>ngfactory</tabTrigger>
-    <scope>source.js</scope>
+    <scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.filter.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.filter.sublime-snippet
@@ -19,5 +19,5 @@
 })();
 ]]></content>
     <tabTrigger>ngfilter</tabTrigger>
-    <scope>source.js</scope>
+    <scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.module.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.module.sublime-snippet
@@ -9,5 +9,5 @@
 })();
 ]]></content>
     <tabTrigger>ngmodule</tabTrigger>
-    <scope>source.js</scope>
+    <scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.service.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.service.sublime-snippet
@@ -20,5 +20,5 @@
 })();
 ]]></content>
     <tabTrigger>ngservice</tabTrigger>
-    <scope>source.js</scope>
+    <scope>text.plain, source.js</scope>
 </snippet>


### PR DESCRIPTION
Modify snippets so that they may be used not only on JavaScript files,
but also on plain text files (new files).

Caveat: Autocompletion does not work on plain text files. You must type
"ngcontroller" in full to activate the snippet.