### PR TITLE
Credit translators in the traduction section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ Many of my styles have been from the many pair programming sessions [Ward Bell](
 While this guide explains the *what*, *why* and *how*, I find it helpful to see them in practice. This guide is accompanied by a sample application that follows these styles and patterns. You can find the [sample application (named modular) here](https://github.com/johnpapa/ng-demos) in the `modular` folder. Feel free to grab it, clone it, or fork it. [Instructions on running it are in its readme](https://github.com/johnpapa/ng-demos/tree/master/modular).
 
 ##Translations
-[Translations of this Angular style guide](https://github.com/johnpapa/angular-styleguide/tree/master/i18n) are maintained by the community and can be found here.
+[Translations of this Angular style guide](https://github.com/johnpapa/angular-styleguide/tree/master/i18n) are maintained thanks to the community and can be found here.
+
+>The [original English version](http://jpapa.me/ngstyles) is the source of truth, as it is maintained and updated first.
+
+  1. [French](i18n/fr-FR.md) by [Eric Le Merdy](https://github.com/ericlemerdy), [Xavier Haniquaut] (@xavhan)
+  1. [German](i18n/de-DE.md) by [Michael Seeger](https://github.com/miseeger), [Sascha Hagedorn](https://github.com/saesh), [Johannes Weber](https://github.com/johannes-weber)
+  1. [Italian](i18n/it-IT.md) by [Angelo Chiello] (@angelochiello)
+  1. [Japanese](i18n/ja-JP.md) by [@noritamago](https://github.com/noritamago)
+  1. [Macedonian](i18n/mk-MK.md) by [Aleksandar Bogatinov](https://github.com/Bogatinov)
+  1. [Portuguese-Brazil](i18n/PT-BR.md) by [Vinicius Sabadim Fernandes](https://github.com/vinicius-sabadim)
+  1. [Russian](i18n/ru-RU.md) by [Vasiliy Mazhekin](https://github.com/mazhekin)
+  1. [Simplified Chinese](i18n/zh-CN.md) by [Zhao Ke](https://github.com/natee)
+  1. [Spanish](i18n/es-ES.md) by [Alberto Calleja](https://github.com/AlbertoImpl), [Gilberto](https://github.com/ingilniero)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
 
   1. [French](i18n/fr-FR.md) by [Eric Le Merdy](https://github.com/ericlemerdy), [Xavier Haniquaut] (@xavhan)
   1. [German](i18n/de-DE.md) by [Michael Seeger](https://github.com/miseeger), [Sascha Hagedorn](https://github.com/saesh), [Johannes Weber](https://github.com/johannes-weber)
-  1. [Italian](i18n/it-IT.md) by [Angelo Chiello] (@angelochiello)
+  1. [Italian](i18n/it-IT.md) by [Angelo Chiello](https://github.com/angelochiello)
   1. [Japanese](i18n/ja-JP.md) by [@noritamago](https://github.com/noritamago)
   1. [Macedonian](i18n/mk-MK.md) by [Aleksandar Bogatinov](https://github.com/Bogatinov)
   1. [Portuguese-Brazil](i18n/PT-BR.md) by [Vinicius Sabadim Fernandes](https://github.com/vinicius-sabadim)

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -2,38 +2,38 @@
 
 The [original English version](http://jpapa.me/ngstyles) is the source of truth, as it is maintained and updated first.
 
-*All translations are created by and maintained by the community.*
+*All translations are created by and maintained thanks to the community translators.*
 
-1. [French](fr-FR.md)
-2. [German](de-DE.md)
-3. [Italian](it-IT.md)
-4. [Japanese](ja-JP.md)
-5. [Macedonian](mk-MK.md)
-6. [Portuguese-Brazil](PT-BR.md)
-7. [Russian](ru-RU.md)
-8. [Simplified Chinese](zh-CN.md)
-9. [Spanish](es-ES.md)
+  1. [French](i18n/fr-FR.md) by [Eric Le Merdy](https://github.com/ericlemerdy), [Xavier Haniquaut] (@xavhan)
+  1. [German](i18n/de-DE.md) by [Michael Seeger], [Sascha Hagedorn](https://github.com/saesh), [Johannes Weber](https://github.com/miseeger)
+  1. [Italian](i18n/it-IT.md) by [Angelo Chiello] (@angelochiello)
+  1. [Japanese](i18n/ja-JP.md) by [@noritamago](https://github.com/noritamago)
+  1. [Macedonian](i18n/mk-MK.md) by [Aleksandar Bogatinov](https://github.com/Bogatinov)
+  1. [Portuguese-Brazil](i18n/PT-BR.md) by [Vinicius Sabadim Fernandes](https://github.com/vinicius-sabadim)
+  1. [Russian](i18n/ru-RU.md) by [Vasiliy Mazhekin](https://github.com/mazhekin)
+  1. [Simplified Chinese](i18n/zh-CN.md) by [Zhao Ke](https://github.com/natee)
+  1. [Spanish](i18n/es-ES.md) by [Alberto Calleja](https://github.com/AlbertoImpl), [Gilberto](https://github.com/ingilniero)
 
 ## Contributing
-Language translations are welcomed and encouraged. The success of these translations depends on the community. I highly encourage new translation contributions and help to keep them up to date. 
+Language translations are welcomed and encouraged. The success of these translations depends on the community. I highly encourage new translation contributions and help to keep them up to date.
 
 All translations must preserve the intention of the original document.
 
 > All contributions fall under the [MIT License of this repository](https://github.com/johnpapa/angularjs-styleguide#license). In other words, you would be providing these free to the community.
 
-### New Translations 
+### New Translations
 1. Fork the repository
 2. Create a translation file and name it using the 118n standard format.
 3. Put this file in the i18n folder
 4. Translate the original English version to be current with the latest changes
-3. Make a Pull Request 
+3. Make a Pull Request
 
 Once you do these I will merge, point the translation links to it, and enter the translation credit to you.
 
-### Updated Translations 
+### Updated Translations
 1. Fork the repository
 2. Make the translation changes
-3. Make a Pull Request 
+3. Make a Pull Request
 
 Once you do these I will merge, point the translation links to it, and enter the translation credit to you.
 

--- a/i18n/fr-FR.md
+++ b/i18n/fr-FR.md
@@ -25,7 +25,7 @@ Alors que ce guide explique le *quoi*, le *pourquoi* et le *comment*, il m'a ét
 
   1. [Français](i18n/fr-FR.md) par [Eric Le Merdy](https://github.com/ericlemerdy), [Xavier Haniquaut](https://github.com/xavhan)
   1. [Allemand](i18n/de-DE.md) par [Michael Seeger](https://github.com/miseeger), [Sascha Hagedorn](https://github.com/saesh), [Johannes Weber](https://github.com/johannes-weber)
-  1. [Italien](i18n/it-IT.md) par [Angelo Chiello] (@angelochiello)
+  1. [Italien](i18n/it-IT.md) par [Angelo Chiello](https://github.com/angelochiello)
   1. [Japonais](i18n/ja-JP.md) par [@noritamago](https://github.com/noritamago)
   1. [Macédonien](i18n/mk-MK.md) par [Aleksandar Bogatinov](https://github.com/Bogatinov)
   1. [Portugais brésilien](i18n/PT-BR.md) par [Vinicius Sabadim Fernandes](https://github.com/vinicius-sabadim)

--- a/i18n/fr-FR.md
+++ b/i18n/fr-FR.md
@@ -2,10 +2,6 @@
 
 *Le guide d'un point de vue personnel sur le style Angular par [@john_papa](//twitter.com/john_papa)*
 
-*Translated by [Eric Lemerdy](https://github.com/ericlemerdy)*
-
->The [original English version](http://jpapa.me/ngstyles) is the source of truth, as it is maintained and updated first.
-
 Si vous cherchez un guide de style pour la syntaxe, les conventions, et la structuration d'application Angular, alors vous êtes au bon endroit. Ces styles sont basés sur mon expérience de dévelopement avec [Angular](//angularjs.org), mes présentations, [mes cours sur Pluralsight](http://pluralsight.com/training/Authors/Details/john-papa) et mon travail au sein des équipes.
 
 Le but de ce guide de style est de proposer des conseils sur le développement d'applications Angular en montrant les conventions que j'utilise et, plus important encore, les raisons des choix que j'ai pris.
@@ -23,7 +19,19 @@ De nombreux de mes styles proviennent des maintes scéances de pair programming 
 Alors que ce guide explique le *quoi*, le *pourquoi* et le *comment*, il m'a été utile de les visualiser dans la pratique. Ce guide est accompagné par une application d'exemple qui suit ces styles et ces motifs. Vous pouvez trouver l'[application d'exemple (appellée modular) ici](https://github.com/johnpapa/ng-demos) dans le répertoire `modular`. Vous pouvez librement le récupérer, le cloner, ou le dupliquer pour le modifier. [Les instructions pour l'éxécuter sont contenues dans ce readme](https://github.com/johnpapa/ng-demos/tree/master/modular).
 
 ## Traductions
-[Des traductions de ce guide stylistique Angular](https://github.com/johnpapa/angular-styleguide/tree/master/i18n) sont maintenues par la communauté et peuvent être trouvées ici.
+[Les traductions de ce guide stylistique pour Angular](https://github.com/johnpapa/angular-styleguide/tree/master/i18n) sont maintenues grace à la communauté et peuvent être trouvées ici.
+
+>La [version originale](http://jpapa.me/ngstyles) (en anglais) est la base de traduction, elle est maintenue et mise à jour prioritairement.
+
+  1. [Français](i18n/fr-FR.md) par [Eric Le Merdy](https://github.com/ericlemerdy), [Xavier Haniquaut](https://github.com/xavhan)
+  1. [Allemand](i18n/de-DE.md) par [Michael Seeger](https://github.com/miseeger), [Sascha Hagedorn](https://github.com/saesh), [Johannes Weber](https://github.com/johannes-weber)
+  1. [Italien](i18n/it-IT.md) par [Angelo Chiello] (@angelochiello)
+  1. [Japonais](i18n/ja-JP.md) par [@noritamago](https://github.com/noritamago)
+  1. [Macédonien](i18n/mk-MK.md) par [Aleksandar Bogatinov](https://github.com/Bogatinov)
+  1. [Portugais brésilien](i18n/PT-BR.md) par [Vinicius Sabadim Fernandes](https://github.com/vinicius-sabadim)
+  1. [Russe](i18n/ru-RU.md) par [Vasiliy Mazhekin](https://github.com/mazhekin)
+  1. [Chinois simplifié](i18n/zh-CN.md) par [Zhao Ke](https://github.com/natee)
+  1. [Espagnol](i18n/es-ES.md) par [Alberto Calleja](https://github.com/AlbertoImpl), [Gilberto](https://github.com/ingilniero)
 
 ## Table des matières
 


### PR DESCRIPTION
Solution to prevent mismatching lines between the original english file and the translation ones

We talked about this in #492 

And nice side effect, translated guides get more visibility as their links appear in the front page for the non english speaking people.