### PR TITLE
Remove extra spaces from sublime template

### DIFF
--- a/assets/sublime-angular-snippets/angular.directive.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.directive.sublime-snippet
@@ -9,7 +9,7 @@
     ${2:directive}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
 
     /* @ngInject */
-    function ${2:directive} (${3:dependencies}) {
+    function ${2:directive}(${3:dependencies}) {
         // Usage:
         //
         // Creates:
@@ -30,7 +30,7 @@
     }
 
     /* @ngInject */
-    function ${4:Controller} () {
+    function ${4:Controller}() {
 
     }
 })();


### PR DESCRIPTION
Sublime directive template had extra  space between
function namess and parens