### PR TITLE
Added modified snippets for vim's ultisnips plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2974,6 +2974,12 @@ Use file templates or snippets to help follow consistent styles and patterns. He
     - set [neosnippet.vim](https://github.com/Shougo/neosnippet.vim)
     - copy snippets to snippet directory
 
+  - vim UltiSnips snippets that follow these styles and guidelines.
+
+    - Download the [vim Angular UltiSnips snippets](assets/vim-angular-ultisnips?raw=true)
+    - set [UltiSnips](https://github.com/SirVer/ultisnips)
+    - copy snippets to UltiSnips directory
+
     ```javascript
     ngcontroller // creates an Angular controller
     ngdirective  // creates an Angular directive

--- a/assets/vim-angular-ultisnips/javascript_angular.controller.snippets
+++ b/assets/vim-angular-ultisnips/javascript_angular.controller.snippets
@@ -1,0 +1,22 @@
+snippet ngcontroller
+(function() {
+	'use strict';
+
+	angular
+		.module('${1:module}')
+		.controller('${2:Controller}Controller', $2Controller);
+
+	/* @ngInject */
+	function $2Controller(${3:dependencies}) {
+		var vm = this;
+		vm.title = '$2Controller';
+
+		activate();
+
+		////////////////
+
+		function activate() {
+		}
+	}
+})();
+endsnippet

--- a/assets/vim-angular-ultisnips/javascript_angular.directive.snippets
+++ b/assets/vim-angular-ultisnips/javascript_angular.directive.snippets
@@ -1,0 +1,35 @@
+snippet ngdirective
+(function() {
+	'use strict';
+
+	angular
+		.module('${1:module}')
+		.directive('${2:directive}', $2);
+
+	/* @ngInject */
+	function $2(${3:dependencies}) {
+		// Usage:
+		//
+		// Creates:
+		//
+		var directive = {
+			bindToController: true,
+			controller: ${4:Controller},
+			controllerAs: '${5:vm}',
+			link: link,
+			restrict: 'A',
+			scope: {
+			}
+		};
+		return directive;
+
+		function link(scope, element, attrs) {
+		}
+	}
+
+	/* @ngInject */
+	function $4() {
+
+	}
+})();
+endsnippet

--- a/assets/vim-angular-ultisnips/javascript_angular.factory.snippets
+++ b/assets/vim-angular-ultisnips/javascript_angular.factory.snippets
@@ -1,0 +1,22 @@
+snippet ngfactory
+(function() {
+	'use strict';
+
+	angular
+		.module('${1:module}')
+		.factory('${2:factory}', $2);
+
+	/* @ngInject */
+	function $2(${3:dependencies}) {
+		var service = {
+			${4:func}: $4
+		};
+		return service;
+
+		////////////////
+
+		function $4() {
+		}
+	}
+})();
+endsnippet

--- a/assets/vim-angular-ultisnips/javascript_angular.filter.snippets
+++ b/assets/vim-angular-ultisnips/javascript_angular.filter.snippets
@@ -1,0 +1,19 @@
+snippet ngfilter
+(function() {
+	'use strict';
+
+	angular
+		.module('${1:module}')
+		.filter('${2:filter}', $2);
+
+	function $2() {
+		return $2Filter;
+
+		////////////////
+		function $2Filter(${3:params}) {
+			return $3;
+		};
+	}
+
+})();
+endsnippet

--- a/assets/vim-angular-ultisnips/javascript_angular.module.snippets
+++ b/assets/vim-angular-ultisnips/javascript_angular.module.snippets
@@ -1,0 +1,10 @@
+snippet ngmodule
+(function() {
+	'use strict';
+
+	angular
+		.module('${1:module}', [
+			'${2:dependencies}'
+		]);
+})();
+endsnippet

--- a/assets/vim-angular-ultisnips/javascript_angular.service.snippets
+++ b/assets/vim-angular-ultisnips/javascript_angular.service.snippets
@@ -1,0 +1,19 @@
+snippet ngservice
+(function() {
+	'use strict';
+
+	angular
+		.module('${1:module}')
+		.service('${2:Service}', $2);
+
+	/* @ngInject */
+	function $2(${3:dependencies}) {
+		this.${4:func} = $4;
+
+		////////////////
+
+		function $4() {
+		}
+	}
+})();
+endsnippet


### PR DESCRIPTION
[Re. UltiSnips issue](https://github.com/johnpapa/angular-styleguide/issues/497)

[UltiSnips](https://github.com/SirVer/ultisnips) seems to be the most popular snippets solution for vim right now, and since the snippets in the repo seemed useful I modified them to work with UltiSnips.  I am probably not the only person who would find them useful. 

Filenames are prepended with 'javascript_' so UltiSnips will load the snippets for javascript files.