### PR TITLE
Update directives filenames in Y070 to match naming conventions (Y121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,7 +1062,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
 
   ```javascript
   /* recommended */
-  /* calendarRange.directive.js */
+  /* calendar-range.directive.js */
 
   /**
    * @desc order directive that is specific to the order module at a company named Acme
@@ -1079,7 +1079,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
 
   ```javascript
   /* recommended */
-  /* customerInfo.directive.js */
+  /* customer-info.directive.js */
 
   /**
    * @desc sales directive that can be used anywhere across the sales app at a company named Acme


### PR DESCRIPTION
Even though it's not explicitly stated by the guidelines, 'feature' section of filenames is usually in `kebab-case` instead of `camelCase`, so this PR fix the Y070 examples to stay consistent with other examples (this is also the naming convention for directive files in [Generator hottowel](https://github.com/johnpapa/generator-hottowel/tree/master/app/templates/src/client/app/widgets))