### PR TITLE
Convert spaces -> tabs in sublime snippets.

### DIFF
--- a/assets/sublime-angular-snippets/angular.controller.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.controller.sublime-snippet
@@ -1,27 +1,27 @@
 <snippet>
-    <content><![CDATA[(function() {
-    'use strict';
+	<content><![CDATA[(function() {
+	'use strict';
 
-    angular
-        .module('${1:module}')
-        .controller('${2:Controller}', ${2:Controller});
+	angular
+		.module('${1:module}')
+		.controller('${2:Controller}', ${2:Controller});
 
-    ${2:Controller}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+	${2:Controller}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
 
-    /* @ngInject */
-    function ${2:Controller}(${3:dependencies}) {
-        var vm = this;
-        vm.title = '${2:Controller}';
+	/* @ngInject */
+	function ${2:Controller}(${3:dependencies}) {
+		var vm = this;
+		vm.title = '${2:Controller}';
 
-        activate();
+		activate();
 
-        ////////////////
+		////////////////
 
-        function activate() {
-        }
-    }
+		function activate() {
+		}
+	}
 })();
 ]]></content>
-    <tabTrigger>ngcontroller</tabTrigger>
-    <scope>text.plain, source.js</scope>
+	<tabTrigger>ngcontroller</tabTrigger>
+	<scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.directive.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.directive.sublime-snippet
@@ -1,40 +1,40 @@
 <snippet>
-    <content><![CDATA[(function() {
-    'use strict';
+	<content><![CDATA[(function() {
+	'use strict';
 
-    angular
-        .module('${1:module}')
-        .directive('${2:directive}', ${2:directive});
+	angular
+		.module('${1:module}')
+		.directive('${2:directive}', ${2:directive});
 
-    ${2:directive}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+	${2:directive}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
 
-    /* @ngInject */
-    function ${2:directive}(${3:dependencies}) {
-        // Usage:
-        //
-        // Creates:
-        //
-        var directive = {
-            bindToController: true,
-            controller: ${4:Controller},
-            controllerAs: '${5:vm}',
-            link: link,
-            restrict: 'A',
-            scope: {
-            }
-        };
-        return directive;
+	/* @ngInject */
+	function ${2:directive}(${3:dependencies}) {
+		// Usage:
+		//
+		// Creates:
+		//
+		var directive = {
+			bindToController: true,
+			controller: ${4:Controller},
+			controllerAs: '${5:vm}',
+			link: link,
+			restrict: 'A',
+			scope: {
+			}
+		};
+		return directive;
 
-        function link(scope, element, attrs) {
-        }
-    }
+		function link(scope, element, attrs) {
+		}
+	}
 
-    /* @ngInject */
-    function ${4:Controller}() {
+	/* @ngInject */
+	function ${4:Controller}() {
 
-    }
+	}
 })();
 ]]></content>
-    <tabTrigger>ngdirective</tabTrigger>
-    <scope>text.plain, source.js</scope>
+	<tabTrigger>ngdirective</tabTrigger>
+	<scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.factory.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.factory.sublime-snippet
@@ -1,27 +1,27 @@
 <snippet>
-    <content><![CDATA[(function() {
-    'use strict';
+	<content><![CDATA[(function() {
+	'use strict';
 
-    angular
-        .module('${1:module}')
-        .factory('${2:factory}', ${2:factory});
+	angular
+		.module('${1:module}')
+		.factory('${2:factory}', ${2:factory});
 
-    ${2:factory}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+	${2:factory}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
 
-    /* @ngInject */
-    function ${2:Factory}(${3:dependencies}) {
-        var service = {
-            ${4:func}: ${4:func}
-        };
-        return service;
+	/* @ngInject */
+	function ${2:Factory}(${3:dependencies}) {
+		var service = {
+			${4:func}: ${4:func}
+		};
+		return service;
 
-        ////////////////
+		////////////////
 
-        function ${4:function}() {
-        }
-    }
+		function ${4:function}() {
+		}
+	}
 })();
 ]]></content>
-    <tabTrigger>ngfactory</tabTrigger>
-    <scope>text.plain, source.js</scope>
+	<tabTrigger>ngfactory</tabTrigger>
+	<scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.filter.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.filter.sublime-snippet
@@ -1,23 +1,23 @@
 <snippet>
-    <content><![CDATA[(function() {
-    'use strict';
+	<content><![CDATA[(function() {
+	'use strict';
 
-    angular
-        .module('${1:module}')
-        .filter('${2:filter}', ${2:filter});
+	angular
+		.module('${1:module}')
+		.filter('${2:filter}', ${2:filter});
 
-    function ${2:filter}() {
-        return ${2:filter}Filter;
+	function ${2:filter}() {
+		return ${2:filter}Filter;
 
-        ////////////////
+		////////////////
 
-        function ${2:filter}Filter(${3:params}) {
-            return ${3:params};
-        }
-    }
+		function ${2:filter}Filter(${3:params}) {
+			return ${3:params};
+		}
+	}
 
 })();
 ]]></content>
-    <tabTrigger>ngfilter</tabTrigger>
-    <scope>text.plain, source.js</scope>
+	<tabTrigger>ngfilter</tabTrigger>
+	<scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.module.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.module.sublime-snippet
@@ -1,13 +1,13 @@
 <snippet>
-    <content><![CDATA[(function() {
-    'use strict';
+	<content><![CDATA[(function() {
+	'use strict';
 
-    angular
-        .module('${1:module}', [
-            '${2:dependencies}'
-        ]);
+	angular
+		.module('${1:module}', [
+			'${2:dependencies}'
+		]);
 })();
 ]]></content>
-    <tabTrigger>ngmodule</tabTrigger>
-    <scope>text.plain, source.js</scope>
+	<tabTrigger>ngmodule</tabTrigger>
+	<scope>text.plain, source.js</scope>
 </snippet>

--- a/assets/sublime-angular-snippets/angular.service.sublime-snippet
+++ b/assets/sublime-angular-snippets/angular.service.sublime-snippet
@@ -1,24 +1,24 @@
 <snippet>
-    <content><![CDATA[(function() {
-    'use strict';
+	<content><![CDATA[(function() {
+	'use strict';
 
-    angular
-        .module('${1:module}')
-        .service('${2:Service}', ${2:Service});
+	angular
+		.module('${1:module}')
+		.service('${2:Service}', ${2:Service});
 
-    ${2:Service}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
+	${2:Service}.\$inject = [${3/(\$(\w+)|\w+)/'$1'/g}];
 
-    /* @ngInject */
-    function ${2:Service}(${3:dependencies}) {
-        this.${4:func} = ${4:func};
+	/* @ngInject */
+	function ${2:Service}(${3:dependencies}) {
+		this.${4:func} = ${4:func};
 
-        ////////////////
+		////////////////
 
-        function ${4:function}() {
-        }
-    }
+		function ${4:function}() {
+		}
+	}
 })();
 ]]></content>
-    <tabTrigger>ngservice</tabTrigger>
-    <scope>text.plain, source.js</scope>
+	<tabTrigger>ngservice</tabTrigger>
+	<scope>text.plain, source.js</scope>
 </snippet>


### PR DESCRIPTION
Sublime's documentation says to always use tabs for indentation in snippets.
They are automatically transformed when translateTabsToSpaces is true.

>When writing a snippet that contains indentation, always use tabs. The tabs will be transformed into spaces when the snippet is inserted if the option translateTabsToSpaces is set to true.
(http://sublimetext.info/docs/en/extensibility/snippets.html#snippets-file-format)

I know this styleguide prefers spaces for indentation, but these snippets are more portable like this, as they will be much easier to use in projects that use tabs.