### PR TITLE
Fixed broken link to pt-BR translation

### DIFF
--- a/i18n/README.md
+++ b/i18n/README.md
@@ -9,7 +9,7 @@ The [original English version](http://jpapa.me/ngstyles) is the source of truth,
   1. [Italian](it-IT.md) by [Angelo Chiello](https://github.com/angelochiello)
   1. [Japanese](ja-JP.md) by [@noritamago](https://github.com/noritamago)
   1. [Macedonian](mk-MK.md) by [Aleksandar Bogatinov](https://github.com/Bogatinov)
-  1. [Portuguese-Brazil](PT-BR.md) by [Vinicius Sabadim Fernandes](https://github.com/vinicius-sabadim)
+  1. [Portuguese-Brazil](pt-BR.md) by [Vinicius Sabadim Fernandes](https://github.com/vinicius-sabadim)
   1. [Russian](ru-RU.md) by [Vasiliy Mazhekin](https://github.com/mazhekin)
   1. [Simplified Chinese](zh-CN.md) by [Zhao Ke](https://github.com/natee)
   1. [Spanish](es-ES.md) by [Alberto Calleja](https://github.com/AlbertoImpl) and [Gilberto](https://github.com/ingilniero)


### PR DESCRIPTION
The link was pointing to PT-BR, which is wrong. The correct link is pt-BR, lowercase.