### PR TITLE
Promote use of services instead of defaulting everything to factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
 ### Singletons
 ###### [Style [Y040](#style-y040)]
 
-  - Services are instantiated with the `new` keyword, use `this` for public methods and variables. Since these are so similar to factories, use a factory instead for consistency.
+  - Services are instantiated with the `new` keyword, use `this` for public methods and variables.
 
     Note: [All Angular services are singletons](https://docs.angularjs.org/guide/services). This means that there is only one instance of a given service per injector.
 
@@ -753,7 +753,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
 ### Singletons
 ###### [Style [Y051](#style-y051)]
 
-  - Factories are singletons and return an object that contains the members of the service.
+  - Factories are singletons and return an object that contains the members of the service. Use factories if custom initialization is needed for example, if some properties are conditiona. If only simple singleton is needed, use Service patern
 
     Note: [All Angular services are singletons](https://docs.angularjs.org/guide/services).
 

--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
 ### Singletons
 ###### [Style [Y051](#style-y051)]
 
-  - Factories are singletons and return an object that contains the members of the service. Use factories if custom initialization is needed for example, if some properties are conditiona. If only simple singleton is needed, use Service patern
+  - Factories are singletons and return an object that contains the members of the service. Use factories if custom initialization is needed. For example, if some properties of the created object are conditional. If only simple singleton is needed, use Service pattern
 
     Note: [All Angular services are singletons](https://docs.angularjs.org/guide/services).
 


### PR DESCRIPTION
Differences between Factories and Services are nicely explained in this article:
http://www.simplygoodcode.com/2015/11/the-difference-between-service-provider-and-factory-in-angularjs/

Provider, Factory and Service all accomplish the same thing, Provider being the most general and Service being the most specific, but:

"you use the most specialize version that accomplishes your goal. Say for example you are returning an existing object defined somewhere else that takes constructor arguments. You can’t pass arguments to the service, so you would make the call with a factory instead."