### PR TITLE
alphabetize private functions

### DIFF
--- a/a2/README.md
+++ b/a2/README.md
@@ -223,17 +223,17 @@ Translations of this Angular 2 style guide are maintained by the community. Due 
     }
 
     // private functions
+    private _hide() {
+      this._toastElement.style.opacity = 0;
+      window.setTimeout(() => this._toastElement.style.zIndex = 0, 400);
+    }
+    
     private _show() {
       console.log(this.message);
       this._toastElement.style.opacity = 1;
       this._toastElement.style.zIndex = 9999;
 
       window.setTimeout(() => this._hide(), 2500);
-    }
-
-    private _hide() {
-      this._toastElement.style.opacity = 0;
-      window.setTimeout(() => this._toastElement.style.zIndex = 0, 400);
     }
   }
   ```


### PR DESCRIPTION
The description says 

> Place properties up top, then public functions, then private functions, **alphabetized**, and not spread through the component code 

Emphasis mine. I assume that applies to private functions as well? If so, submitting this patch for the same