### PR TITLE
Use same controller name as rest of guide

### DIFF
--- a/a1/README.md
+++ b/a1/README.md
@@ -711,7 +711,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
       $routeProvider
           .when('/avengers', {
               templateUrl: 'avengers.html',
-              controller: 'Avengers',
+              controller: 'AvengersController',
               controllerAs: 'vm'
           });
   }


### PR DESCRIPTION
So there isn't any confusion about a convention that 'Controller' will be automatically appended, explicitly use 'AvengersController' similar to the rest of the guide.

P.S.  Thanks for this amazing guide!