### PR TITLE
$watch controller memebers independent controllerAs allias

### DIFF
--- a/a1/README.md
+++ b/a1/README.md
@@ -414,7 +414,9 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
       var vm = this;
       vm.title = 'Some Title';
 
-      $scope.$watch('vm.title', function(current, original) {
+      $scope.$watch(function(){
+          return vm.title;
+      }, function(current, original) {
           $log.info('vm.title was %s', original);
           $log.info('vm.title is now %s', current);
       });


### PR DESCRIPTION
Watching controller members should not be depend on the controllerAs alias name, it's hard to maintenance, and can make confusing when using multiple instances of the controller in view.
