### PR TITLE
Add ESLint recommendations

### DIFF
--- a/a1/README.md
+++ b/a1/README.md
@@ -50,6 +50,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
   1. [Comments](#comments)
   1. [JSHint](#js-hint)
   1. [JSCS](#jscs)
+  1. [ESLint](#eslint)
   1. [Constants](#constants)
   1. [File Templates and Snippets](#file-templates-and-snippets)
   1. [Yeoman Generator](#yeoman-generator)
@@ -2916,6 +2917,155 @@ Unit testing helps maintain clean code, as such I included some of my recommenda
         "requireParenthesesAroundIIFE": true
     }
     ```
+
+**[Back to top](#table-of-contents)**
+
+## ESLint
+
+### Use an Options File
+###### [Style [Y236](#style-y236)]
+
+  - Use ESLint to check your Javscript coding style. Be sure to include the [ESLint options file](assets/.eslintrc) in your source control. See the [ESLint docs](http://eslint.org/) for details on the options.
+
+    *Why?*: Provides a first alert prior to committing any code to source control.
+
+    *Why?*: Provides consistency across your team.
+
+    ```javascript
+    {
+      "env": {
+        "browser": true,
+        "node": true
+      },
+      "globals": {
+        "angular": false,
+        "$": false
+      },
+      "rules": {
+        "no-bitwise": 2,
+        "camelcase": [
+          2,
+          {
+            "properties": "never"
+          }
+        ],
+        "curly": [
+          2,
+          "all"
+        ],
+        "eqeqeq": 2,
+        "guard-for-in": 2,
+        "no-extend-native": 2,
+        "wrap-iife": 2,
+        "indent": [
+          2,
+          4,
+          {
+            "SwitchCase": 1
+          }
+        ],
+        "no-use-before-define": [
+          2,
+          {
+            "functions": false
+          }
+        ],
+        "new-cap": 2,
+        "no-caller": 2,
+        "no-empty": 2,
+        "no-irregular-whitespace": 2,
+        "no-new": 2,
+        "no-plusplus": 0,
+        "quotes": [
+          2,
+          "single"
+        ],
+        "no-undef": 2,
+        "no-unused-vars": 0,
+        "strict": 0,
+        "max-params": [
+          2,
+          10
+        ],
+        "max-depth": [
+          2,
+          5
+        ],
+        "max-statements": [
+          2,
+          40
+        ],
+        "complexity": [
+          2,
+          8
+        ],
+        "max-len": [
+          2,
+          100
+        ],
+        "semi": 0,
+        "no-cond-assign": 0,
+        "no-debugger": 0,
+        "no-eq-null": 2,
+        "no-eval": 0,
+        "no-unused-expressions": 0,
+        "block-scoped-var": 0,
+        "no-iterator": 0,
+        "linebreak-style": 0,
+        "comma-style": [
+          2,
+          "first"
+        ],
+        "no-loop-func": 2,
+        "no-multi-str": 2,
+        "valid-typeof": 0,
+        "no-proto": 0,
+        "no-script-url": 0,
+        "no-shadow": 2,
+        "dot-notation": 0,
+        "no-new-func": 0,
+        "no-new-wrappers": 0,
+        "no-invalid-this": 0,
+        "require-yield": 0,
+        "operator-linebreak": [
+          2,
+          "after"
+        ],
+        "no-mixed-spaces-and-tabs": 2,
+        "no-trailing-spaces": 2,
+        "space-unary-ops": [
+          2,
+          {
+            "nonwords": false,
+            "overrides": {}
+          }
+        ],
+        "keyword-spacing": [
+          2,
+          {}
+        ],
+        "space-infix-ops": 2,
+        "space-before-blocks": [
+          2,
+          "always"
+        ],
+        "eol-last": 2,
+        "array-bracket-spacing": [
+          2,
+          "never",
+          {
+            "singleValue": true
+          }
+        ],
+        "space-in-parens": [
+          2,
+          "never"
+        ],
+        "valid-jsdoc": 2,
+        "no-multiple-empty-lines": 2
+      }
+    }
+    ```    
 
 **[Back to top](#table-of-contents)**
 

--- a/a1/assets/.eslintrc
+++ b/a1/assets/.eslintrc
@@ -1,0 +1,133 @@
+{
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "globals": {
+    "angular": false,
+    "$": false
+  },
+  "rules": {
+    "no-bitwise": 2,
+    "camelcase": [
+      2,
+      {
+        "properties": "never"
+      }
+    ],
+    "curly": [
+      2,
+      "all"
+    ],
+    "eqeqeq": 2,
+    "guard-for-in": 2,
+    "no-extend-native": 2,
+    "wrap-iife": 2,
+    "indent": [
+      2,
+      4,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "no-use-before-define": [
+      2,
+      {
+        "functions": false
+      }
+    ],
+    "new-cap": 2,
+    "no-caller": 2,
+    "no-empty": 2,
+    "no-irregular-whitespace": 2,
+    "no-new": 2,
+    "no-plusplus": 0,
+    "quotes": [
+      2,
+      "single"
+    ],
+    "no-undef": 2,
+    "no-unused-vars": 0,
+    "strict": 0,
+    "max-params": [
+      2,
+      10
+    ],
+    "max-depth": [
+      2,
+      5
+    ],
+    "max-statements": [
+      2,
+      40
+    ],
+    "complexity": [
+      2,
+      8
+    ],
+    "max-len": [
+      2,
+      100
+    ],
+    "semi": 0,
+    "no-cond-assign": 0,
+    "no-debugger": 0,
+    "no-eq-null": 2,
+    "no-eval": 0,
+    "no-unused-expressions": 0,
+    "block-scoped-var": 0,
+    "no-iterator": 0,
+    "linebreak-style": 0,
+    "comma-style": [
+      2,
+      "first"
+    ],
+    "no-loop-func": 2,
+    "no-multi-str": 2,
+    "valid-typeof": 0,
+    "no-proto": 0,
+    "no-script-url": 0,
+    "no-shadow": 2,
+    "dot-notation": 0,
+    "no-new-func": 0,
+    "no-new-wrappers": 0,
+    "no-invalid-this": 0,
+    "require-yield": 0,
+    "operator-linebreak": [
+      2,
+      "after"
+    ],
+    "no-mixed-spaces-and-tabs": 2,
+    "no-trailing-spaces": 2,
+    "space-unary-ops": [
+      2,
+      {
+        "nonwords": false,
+        "overrides": {}
+      }
+    ],
+    "keyword-spacing": [
+      2,
+      {}
+    ],
+    "space-infix-ops": 2,
+    "space-before-blocks": [
+      2,
+      "always"
+    ],
+    "eol-last": 2,
+    "array-bracket-spacing": [
+      2,
+      "never",
+      {
+        "singleValue": true
+      }
+    ],
+    "space-in-parens": [
+      2,
+      "never"
+    ],
+    "valid-jsdoc": 2,
+    "no-multiple-empty-lines": 2
+  }
+}


### PR DESCRIPTION
This is the output of the recommended jshint and jscs options after passing through polyjuice. I also added a .eslintrc which can be downloaded from the repo as well.

Let me know if this is acceptable or if I should make any additional refinements.

closes #770 
closes #696 
partially addresses #732, but JSCS should probably be removed from the styleguide after a deprecation period since it is not a part of ESLint. 
