### PR TITLE
Changed confusing vm controllerAs name

### DIFF
--- a/a1/README.md
+++ b/a1/README.md
@@ -712,7 +712,7 @@ While this guide explains the *what*, *why* and *how*, I find it helpful to see 
           .when('/avengers', {
               templateUrl: 'avengers.html',
               controller: 'Avengers',
-              controllerAs: 'vm'
+              controllerAs: 'avengers'
           });
   }
   ```


### PR DESCRIPTION
I found myself working in a huge project with the whole view full of vm.whatever. When I ask my team mates why did they do that, they told me "It´s in John´s Papa´s styleguide" because of this misconception at this point of the guide. If I´m wrong sorry and let me know. Thanks.
