### PR TITLE
Update es-ES.md

### DIFF
--- a/a1/i18n/es-ES.md
+++ b/a1/i18n/es-ES.md
@@ -2711,7 +2711,7 @@ Usa Plantillas o snippets para ayudarte a seguir estilos consistentes o patrones
 ### WebStorm
 ###### [Style [Y252](#style-y252)]
 
-  - Snippets y arhivos de Angular que siguen estos estilos y directrices. Puedes importarlos en tus configuraciones de WebStorm:
+  - Snippets y archivos de Angular que siguen estos estilos y directrices. Puedes importarlos en tus configuraciones de WebStorm:
 
     - Descarga los [snippets y plantillas de Angular para WebStorm](assets/webstorm-angular-file-template.settings.jar?raw=true)
     - Abre WebStorm y ve al menú `File`

--- a/a1/i18n/es-ES.md
+++ b/a1/i18n/es-ES.md
@@ -176,7 +176,7 @@ Mientras que esta guía explica el *qué*, *por qué* y *cómo*, me resulta úti
 
   - Nota: Para acortar únicamente, el resto de los ejemplos de esta guía podrían omitir la sintaxis IIFE.
 
-  - Nota: IIFE previente que el código de los tests llegue a sus variables privadas, como expresiones regulares o funciones de ayuda que normalmente vienen bien para hacer pruebas por sí solas. Sin embargo, puedes acceder a ellas creando accesorios o accediendo a través de sus componentes. Por ejemplo, poniendo las funciones de ayuda, expresiones regulares o constantes en su propia factoría.
+  - Nota: IIFE previene que el código de los tests llegue a sus variables privadas, como expresiones regulares o funciones de ayuda que normalmente vienen bien para hacer pruebas por sí solas. Sin embargo, puedes acceder a ellas creando accesorios o accediendo a través de sus componentes. Por ejemplo, poniendo las funciones de ayuda, expresiones regulares o constantes en su propia factoría.
 
 **[Volver arriba](#tabla-de-contenidos)**
 


### PR DESCRIPTION
Fix typo, as commented in https://github.com/johnpapa/angular-styleguide/pull/816#issuecomment-283070773
The word is "archivos".
"arhivos" doesn't exist. :)