### PR TITLE
Fix translations header

### DIFF
--- a/a1/README.md
+++ b/a1/README.md
@@ -22,7 +22,8 @@ Many of my styles have been from the many pair programming sessions [Ward Bell](
 ## See the Styles in a Sample App
 While this guide explains the *what*, *why* and *how*, I find it helpful to see them in practice. This guide is accompanied by a sample application that follows these styles and patterns. You can find the [sample application (named modular) here](https://github.com/johnpapa/ng-demos) in the `modular` folder. Feel free to grab it, clone it, or fork it. [Instructions on running it are in its readme](https://github.com/johnpapa/ng-demos/tree/master/modular).
 
-##Translations
+## Translations
+
 [Translations of this Angular style guide](https://github.com/johnpapa/angular-styleguide/tree/master/a1/i18n) are maintained by the community and can be found here.
 
 ## Table of Contents


### PR DESCRIPTION
This header needs an extra space so it displays properly:

![](https://dl.dropboxusercontent.com/spa/0n9xxbuk27dn14b/bqitn031.png)