### PR TITLE
Use the correct name "lifecycle hooks"

### DIFF
--- a/a1/README.md
+++ b/a1/README.md
@@ -1246,7 +1246,7 @@ Note: There are many naming options for directives, especially since they can be
 
     Note: Note that the directive's controller is outside the directive's closure. This style eliminates issues where the injection gets created as unreachable code after a `return`.
     
-    Note: Life-style hooks were introduced in Angular 1.5. Initialization logic that relies on bindings being present should be put in the controller's $onInit() method, which is guarranteed to always be called after the bindings have been assigned.
+    Note: Lifecycle hooks were introduced in Angular 1.5. Initialization logic that relies on bindings being present should be put in the controller's $onInit() method, which is guarranteed to always be called after the bindings have been assigned.
 
   ```html
   <div my-example max="77"></div>


### PR DESCRIPTION
Using the correct name for "lifecycle hooks" (as in the AngularJS documentation https://docs.angularjs.org/guide/component) ensures that users find the corresponding paragraph.