### PR TITLE
feat: add AI-ready configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,35 @@
+name: "\U0001F41B Bug Report"
+description: Report an error or inconsistency in the style guide
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the Angular Style Guide! Please provide as much detail as possible.
+  - type: input
+    id: guide-version
+    attributes:
+      label: Which guide?
+      description: Which version of the style guide does this affect?
+      placeholder: "e.g., Angular 1 (a1/README.md) or Angular 2 (a2/README.md)"
+    validations:
+      required: true
+  - type: input
+    id: style-id
+    attributes:
+      label: Style ID (if applicable)
+      description: "The rule ID, e.g., Y001, Y032"
+      placeholder: "e.g., Y032"
+  - type: textarea
+    id: description
+    attributes:
+      label: What's wrong?
+      description: Describe the error, inconsistency, or outdated information
+      placeholder: "The code example in Y032 uses var instead of const/let..."
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: How should it be corrected?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,46 @@
+name: "\U0001F4A1 New Style Rule"
+description: Propose a new style rule or convention
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a convention that should be in the guide? Propose it here.
+  - type: input
+    id: guide-version
+    attributes:
+      label: Which guide?
+      description: Which version of the style guide should this be added to?
+      placeholder: "e.g., Angular 1 (a1) or Angular 2 (a2)"
+    validations:
+      required: true
+  - type: input
+    id: rule-title
+    attributes:
+      label: Rule title
+      description: A short, descriptive name for the rule
+      placeholder: "e.g., Use trackBy with ngFor"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What's the rule?
+      description: Describe the convention you're proposing
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: "Why?"
+      description: "Explain the rationale — use the *Why?*: format"
+      placeholder: |
+        *Why?*: Using trackBy prevents unnecessary DOM re-renders when the list changes.
+        *Why?*: Without trackBy, Angular destroys and recreates every DOM element on each change detection cycle.
+    validations:
+      required: true
+  - type: textarea
+    id: examples
+    attributes:
+      label: Code examples
+      description: "Show /* avoid */ and /* recommended */ examples"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Changes
+
+<!-- List the files changed and why -->
+- 
+
+## Style Rule Details (if adding/modifying a rule)
+
+- **Style ID:** <!-- e.g., Y250 -->
+- **Guide:** <!-- a1 or a2 -->
+- **Added to TOC:** <!-- yes/no -->
+
+## Checklist
+
+- [ ] Rule includes `*Why?*:` rationale bullets
+- [ ] Code examples show both `/* avoid */` and `/* recommended */`
+- [ ] Style ID follows the numbering convention
+- [ ] Added to Table of Contents
+- [ ] `**[Back to top](#table-of-contents)**` link at end of section
+- [ ] Flagged affected translations in `a1/i18n/` (if applicable)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# Copilot Instructions — Angular Style Guide
+
+## Project Type
+
+This is a **documentation-only repository** — markdown files containing style rules for Angular development. There is no source code to build or test.
+
+## Writing Conventions
+
+### The *Why?* Pattern
+
+Every recommendation must include one or more `*Why?*:` bullets explaining the rationale. This is the signature pattern of the guide — never skip it.
+
+```markdown
+  *Why?*: One component per file promotes easier unit testing and mocking.
+
+  *Why?*: One component per file makes it far easier to read, maintain, and avoid collisions with teams in source control.
+```
+
+### Code Examples
+
+Always show both the wrong way and the right way:
+
+```javascript
+  /* avoid */
+  // bad pattern here
+
+  /* recommended */
+  // good pattern here
+```
+
+### Style IDs
+
+Every rule gets a unique ID in the format `[Style [Y###](#style-y###)]`. IDs are sequential within their category. When adding a new rule, use the next available number in the relevant section.
+
+### Formatting
+
+- Use ATX-style headings (`#`, `##`, `###`)
+- Indent code blocks with 2 spaces inside list items
+- End each section with `**[Back to top](#table-of-contents)**`
+- Use fenced code blocks with `javascript` or `html` language identifiers
+
+## Content Rules
+
+- **Be opinionated** — "My recommended pattern is..." not "You might want to consider..."
+- **Be specific** — real code, real patterns, real file names
+- **Keep rules focused** — one concept per rule, one purpose per section
+- **Explain tradeoffs** — when a rule has exceptions, note them
+
+## Maintenance Matrix
+
+| Change Made | Files to Update |
+|---|---|
+| New Angular 1 rule added | `a1/README.md` (rule + TOC entry) |
+| Existing rule modified | `a1/README.md`, flag translations in `a1/i18n/` for review |
+| New Angular 2+ rule added | `a2/README.md` |
+| Style ID numbering changed | Update all references in the TOC and cross-links |
+| New translation added | `a1/i18n/{locale}.md`, update root `README.md` if needed |
+| Assets added (images, snippets) | `a1/assets/`, reference from the relevant guide |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Angular Style Guide — Agent Guide
+
+## Project Overview
+
+*Opinionated Angular style guide for teams by [John Papa](https://github.com/johnpapa).* This is the most widely adopted Angular style guide (26k+ stars), endorsed by the Angular team. It provides conventions for building Angular applications — syntax, structure, naming, and patterns — with *Why?* explanations for every recommendation.
+
+This is a **documentation-only repository**. There is no source code, no build system, no test framework, and no runtime dependencies. The deliverables are markdown files.
+
+## Repository Structure
+
+```
+angular-styleguide/
+├── README.md              # Root — links to version-specific guides
+├── a1/                    # Angular 1 (AngularJS) style guide
+│   ├── README.md          # The full Angular 1 guide (~3,300 lines)
+│   ├── assets/            # Images, code snippets, editor templates
+│   └── i18n/              # Community translations (15+ languages)
+├── a2/                    # Angular 2+ style guide
+│   ├── README.md          # Angular 2 guide (references official docs)
+│   └── notes.md           # Development notes
+├── LICENSE                # MIT
+└── .github/               # GitHub configuration (AI-ready assets)
+```
+
+## Tech Stack
+
+- **Content format:** Markdown
+- **No runtime, build system, or test framework** — this is a documentation project
+
+## Build & Run
+
+There is no build step. The content is read directly on GitHub or cloned locally. To preview markdown locally, use any markdown viewer or VS Code preview.
+
+## Testing
+
+There are no automated tests. Validation is manual:
+- Read the markdown for accuracy and completeness
+- Verify code examples compile and follow the conventions they describe
+- Check that links are not broken
+
+## Key Patterns and Conventions
+
+- **The *Why?* pattern** — every rule has one or more `*Why?*:` bullets explaining the rationale
+- **Style IDs** — each rule has a unique ID (e.g., `[Style Y001]`) for easy reference
+- **Avoid / Recommended** — code examples show both the wrong way (`/* avoid */`) and the right way (`/* recommended */`)
+- **LIFT principle** — Locate, Identify, Flat, Try DRY (Y140-Y144)
+- **ATX headings** — `#`, `##`, `###` for structure
+- **Back to top links** — `**[Back to top](#table-of-contents)**` after each section
+
+## Adding a New Style Rule
+
+1. Choose the appropriate guide (`a1/README.md` for AngularJS, `a2/README.md` for Angular 2+)
+2. Assign a new Style ID following the numbering convention (e.g., `Y250` for the next in sequence)
+3. Write the rule with:
+   - A descriptive heading
+   - The style ID as a subheading: `###### [Style [Y250](#style-y250)]`
+   - One or more `*Why?*:` bullets
+   - `/* avoid */` and `/* recommended */` code examples
+4. Add a `**[Back to top](#table-of-contents)**` link at the end
+5. Add the rule to the Table of Contents at the top of the guide
+6. If the rule applies across languages, update translations in `a1/i18n/`
+
+## Documentation
+
+This project **is** documentation. The guides live in:
+- `a1/README.md` — Angular 1 style guide (primary, most complete)
+- `a2/README.md` — Angular 2+ style guide (references official Angular docs)
+
+Translations are maintained by the community in `a1/i18n/`.
+
+## Common Pitfalls
+
+- **Don't forget the Table of Contents** — every new rule must be added to the TOC at the top of the guide
+- **Translations go stale** — when updating `a1/README.md`, the 15+ translations in `a1/i18n/` may need updates. Flag this in the PR but don't auto-update translations.
+- **Code examples must be valid** — the `/* avoid */` and `/* recommended */` examples should be syntactically correct JavaScript/TypeScript
+- **Default branch is `master`** — not `main`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Angular Style Guide
 
+[![AI Ready](https://img.shields.io/badge/AI--Ready-yes-brightgreen?style=flat)](https://github.com/johnpapa/ai-ready)
+
 ## Versions
 There are multiple versions of Angular, and thus there are multiple versions of the guide. Choose your guide appropriately.
 


### PR DESCRIPTION
Make the Angular Style Guide AI-ready — so AI agents know the repo's unique writing patterns and can contribute correctly.

## What's added

| File | Purpose |
|------|---------|
| `AGENTS.md` | Repo structure, *Why?* pattern, Style IDs, how to add a new rule |
| `.github/copilot-instructions.md` | Writing conventions, avoid/recommended format, maintenance matrix |
| `.github/ISSUE_TEMPLATE/bug-report.yml` | Structured form with guide version and Style ID fields |
| `.github/ISSUE_TEMPLATE/feature-request.yml` | New rule proposal with *Why?* rationale and code examples |
| `.github/PULL_REQUEST_TEMPLATE.md` | Checklist: *Why?* bullets, Style IDs, TOC, translations |
| AI-Ready badge in README | Shields.io badge |

## Why

AI agents contributing to this repo need to know:
- Every rule needs `*Why?*:` bullets
- Code examples must show `/* avoid */` and `/* recommended */`
- Rules need Style IDs (`Y001`, `Y032`, etc.)
- New rules must be added to the Table of Contents
- Translations in `a1/i18n/` should be flagged when the English guide changes

Without these instructions, AI-generated PRs will miss the guide's signature patterns.

## Score

🥉 Getting Started (2/11) → 🥈 On Track (7/11)

Generated by [ai-ready](https://github.com/johnpapa/ai-ready).