### PR TITLE
Fix `guarranteed` -> `guaranteed` typo in a1/README

### DIFF
--- a/a1/README.md
+++ b/a1/README.md
@@ -1249,7 +1249,7 @@ Note: There are many naming options for directives, especially since they can be
 
     Note: Note that the directive's controller is outside the directive's closure. This style eliminates issues where the injection gets created as unreachable code after a `return`.
     
-    Note: Lifecycle hooks were introduced in Angular 1.5. Initialization logic that relies on bindings being present should be put in the controller's $onInit() method, which is guarranteed to always be called after the bindings have been assigned.
+    Note: Lifecycle hooks were introduced in Angular 1.5. Initialization logic that relies on bindings being present should be put in the controller's $onInit() method, which is guaranteed to always be called after the bindings have been assigned.
 
   ```html
   <div my-example max="77"></div>


### PR DESCRIPTION
Line 1252 of `a1/README.md` has `guarranteed` (extra r) in the $onInit() lifecycle note.